### PR TITLE
Feature/add userstory link to report

### DIFF
--- a/TestDataAggregator/Models/AzureDevopsAnalyticsClient.cs
+++ b/TestDataAggregator/Models/AzureDevopsAnalyticsClient.cs
@@ -58,7 +58,7 @@ namespace TestInformationAggregator.Models
 		{
 			return this.GetWorkItems("$expand=Links($select=SourceWorkItemId,TargetWorkItemId,LinkTypeName)")
 				.Where(x => (string)x["WorkItemType"] == "Test Case")
-				.Where(y => (string)y["State"] != WorkItemStates.CLOSED);
+				.Where(x => (string)x["State"] != WorkItemStates.CLOSED);
 		}
 
 		/// <summary>

--- a/TestDataAggregator/Models/Builders/TestInformationBuilderBase.cs
+++ b/TestDataAggregator/Models/Builders/TestInformationBuilderBase.cs
@@ -30,16 +30,24 @@ namespace TestInformationAggregator.Models
 		protected Dictionary<string, bool> BuilderOptions { get; set; }
 
 		/// <summary>
+		/// Gets or sets the Delimiter: 
+		///	  - ',' for CSV
+		///	  - '|' for all other output report types
+		/// </summary>
+		protected char Delimiter { get; set; }
+
+		/// <summary>
 		/// Creates the TestInformationCSVBuilder
 		/// </summary>
 		/// <param name="headers"> The headers </param>
 		/// <param name="responseUtility"> The azure analytics response utility </param>
-		protected TestInformationBuilderBase(string headers, AzureAnalyticsResponseUtility responseUtility, Dictionary<string, bool> builderOptions)
+		protected TestInformationBuilderBase(string headers, AzureAnalyticsResponseUtility responseUtility, Dictionary<string, bool> builderOptions, char delimiter = ',')
 		{
 			this.TestInformationHeaders = headers;
 			this.TestInformation = new List<TestInformation>();
 			this.ResponseUtility = responseUtility;
 			this.BuilderOptions = builderOptions;
+			this.Delimiter = delimiter;
 		}
 
 		/// <summary>
@@ -60,7 +68,7 @@ namespace TestInformationAggregator.Models
 			{
 				var testCaseWorkItemsWithoutTestResults = closedTestCasesWithLinks
 					.Where(x => !this.TestInformation.Any(y => (string)x["Title"] == y.TestName))
-					.Select(x => new TestInformation()
+					.Select(x => new TestInformation(this.Delimiter)
 					{
 						WorkItemID = Convert.ToInt32(x["WorkItemId"]),
 						TestName = (string)x["Title"],
@@ -90,7 +98,7 @@ namespace TestInformationAggregator.Models
 		{
 			// SK properties on the azure devops apis are similar to primary/foreign keys, as such, we can join
 			// the results based on the TestSK property
-			this.TestInformation.AddRange(this.ResponseUtility.JoinTestResultToTestcases(testResults, testCases));
+			this.TestInformation.AddRange(this.ResponseUtility.JoinTestResultToTestcases(testResults, testCases, this.Delimiter));
 			return this;
 		}
 

--- a/TestDataAggregator/Models/Builders/TestInformationCSVBuilder.cs
+++ b/TestDataAggregator/Models/Builders/TestInformationCSVBuilder.cs
@@ -10,7 +10,6 @@ namespace TestInformationAggregator.Models
 	/// </summary>
 	public class TestInformationCSVBuilder : TestInformationBuilderBase
 	{
-
 		/// <summary>
 		/// Creates the TestInformationCSVBuilder
 		/// </summary>

--- a/TestDataAggregator/Models/TestInformation.cs
+++ b/TestDataAggregator/Models/TestInformation.cs
@@ -21,6 +21,11 @@ namespace TestInformationAggregator.Models
 		public DateTime CompletedDate { get; set; }
 
 		/// <summary>
+		/// The UserStory ids linked to the test case
+		/// </summary>
+		public IEnumerable<int> UserStoryIdLinks { get; set; }
+
+		/// <summary>
 		/// The TestSK for joining the Test Case to the Test Result
 		/// </summary>
 		public int TestSK { get; set; }
@@ -64,27 +69,28 @@ namespace TestInformationAggregator.Models
 		public override string ToString()
 		{
 			return $"{this.WorkItemID}," +
-				   $"{this.CompletedDate.ToString()}," +
+				   $"{this.GetLinkedIdsAsCSV(this.UserStoryIdLinks)}," +
+				   $"{this.CompletedDate}," +
 				   $"{this.TestSK}," +
 				   $"{this.TestRunType}," +
 				   $"{this.Outcome}," +
 				   $"\"{this.TestName}\"," +
 				   $"{this.TestOwner}," +
 				   $"{this.Priority}," +
-				   $"{this.GetLinkedBugsAsCSV(WorkItemStates.NEW)}," +
-				   $"{this.GetLinkedBugsAsCSV(WorkItemStates.ACTIVE)}," +
-				   $"{this.GetLinkedBugsAsCSV(WorkItemStates.RESOLVED)}," +
-				   $"{this.GetLinkedBugsAsCSV(WorkItemStates.CLOSED)}";
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.NEW))}," +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.ACTIVE))}," +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.RESOLVED))}," +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.CLOSED))}";
 		}
 
 		/// <summary>
-		/// Gets the linked bugs using the provided state into a comma separated list
+		/// Gets the linked ids into a comma separated list
 		/// </summary>
-		/// <param name="state"> the state to try and get the bug ids from</param>
-		/// <returns> the linked bug ids as a comma separated list </returns>
-		private string GetLinkedBugsAsCSV(string state)
+		/// <param name="linkedIds"> the ids being aggregated </param>
+		/// <returns> the linked ids as a comma separated list </returns>
+		private string GetLinkedIdsAsCSV(IEnumerable<int> linkedIds)
 		{
-			return $"\"{this.GetLinkedBugs(state)?.Select(x => x.ToString()).Aggregate((acc, curr) => acc + ", " + curr)}\"";
+			return $"\"{linkedIds?.Select(x => x.ToString()).Aggregate((acc, curr) => acc + ", " + curr)}\"";
 		}
 
 		/// <summary>

--- a/TestDataAggregator/Models/TestInformation.cs
+++ b/TestDataAggregator/Models/TestInformation.cs
@@ -11,6 +11,15 @@ namespace TestInformationAggregator.Models
 	public class TestInformation
 	{
 		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="delimiter">The delimiter for the TestInfo ToString </param>
+		public TestInformation(char delimiter)
+		{
+			this.Delimiter = delimiter;
+		}
+
+		/// <summary>
 		/// The WorkItemID of the test case
 		/// </summary>
 		public int WorkItemID { get; set; }
@@ -62,24 +71,29 @@ namespace TestInformationAggregator.Models
 		public Dictionary<string, List<int>> LinkedBugsByState { get; set; }
 
 		/// <summary>
+		/// The delimiter used in the TestInformation ToString 
+		/// </summary>
+		private char Delimiter { get; set; }
+
+		/// <summary>
 		/// To String method to represent properties in appropriately ordered
 		/// comma delimited string for csv generation
 		/// </summary>
 		/// <returns> The object in ordered csv format</returns>
 		public override string ToString()
 		{
-			return $"{this.WorkItemID}," +
-				   $"{this.GetLinkedIdsAsCSV(this.UserStoryIdLinks)}," +
-				   $"{this.CompletedDate}," +
-				   $"{this.TestSK}," +
-				   $"{this.TestRunType}," +
-				   $"{this.Outcome}," +
-				   $"\"{this.TestName}\"," +
-				   $"{this.TestOwner}," +
-				   $"{this.Priority}," +
-				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.NEW))}," +
-				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.ACTIVE))}," +
-				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.RESOLVED))}," +
+			return $"{this.WorkItemID}{this.Delimiter}" +
+				   $"{this.GetLinkedIdsAsCSV(this.UserStoryIdLinks)}{this.Delimiter}" +
+				   $"{this.CompletedDate}{this.Delimiter}" +
+				   $"{this.TestSK}{this.Delimiter}" +
+				   $"{this.TestRunType}{this.Delimiter}" +
+				   $"{this.Outcome}{this.Delimiter}" +
+				   $"\"{this.TestName}\"{this.Delimiter}" +
+				   $"{this.TestOwner}{this.Delimiter}" +
+				   $"{this.Priority}{this.Delimiter}" +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.NEW))}{this.Delimiter}" +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.ACTIVE))}{this.Delimiter}" +
+				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.RESOLVED))}{this.Delimiter}" +
 				   $"{this.GetLinkedIdsAsCSV(this.GetLinkedBugs(WorkItemStates.CLOSED))}";
 		}
 

--- a/TestDataAggregator/Program.cs
+++ b/TestDataAggregator/Program.cs
@@ -20,7 +20,7 @@ namespace TestInformationAggregator
 			string outputDir = config.Configuration.OutputDirectory;
 
 			string testInformationHeaders =
-				$"WorkItemID,CompletedDate,TestSK,TestRunType,Outcome,TestName,TestOwner,Priority," +
+				$"WorkItemID,Linked UserStoryIds,CompletedDate,TestSK,TestRunType,Outcome,TestName,TestOwner,Priority," +
 				$"Linked Bugs({WorkItemStates.NEW}),Linked Bugs({WorkItemStates.ACTIVE}),Linked Bugs({WorkItemStates.RESOLVED}),Linked Bugs({WorkItemStates.CLOSED})" +
 				$"{Environment.NewLine}";
 
@@ -44,7 +44,7 @@ namespace TestInformationAggregator
 				.Build();
 
 			FileWriter.Write(
-				outputDir,
+				string.IsNullOrEmpty(outputDir) ? Environment.GetFolderPath(Environment.SpecialFolder.Desktop) : outputDir,
 				$"{organization}{project}TestReport_{DateTime.Now:yyyy-dd-M--HH-mm-ss}.csv",
 				testInformationReport);
 		}

--- a/TestDataAggregator/Services/AzureAnalyticsResponseUtility.cs
+++ b/TestDataAggregator/Services/AzureAnalyticsResponseUtility.cs
@@ -16,13 +16,14 @@ namespace TestInformationAggregator.Services
 		/// </summary>
 		/// <param name="testResults"> The test results to join </param>
 		/// <param name="testCases"> the test cases to join </param>
+		/// <param name="delimiter"> the delimiter used by the TestInformation </param>
 		/// <returns> the joined test information </returns>
-		public IEnumerable<TestInformation> JoinTestResultToTestcases(JToken testResults, JToken testCases)
+		public IEnumerable<TestInformation> JoinTestResultToTestcases(JToken testResults, JToken testCases, char delimiter)
 		{
 			return from testResult in testResults
 				   join testCase in testCases
 				   on (string)testResult["TestSK"] equals (string)testCase["TestSK"]
-				   select new TestInformation()
+				   select new TestInformation(delimiter)
 				   {
 					   CompletedDate = Convert.ToDateTime(testResult["CompletedDate"]),
 					   TestSK = Convert.ToInt32(testResult["TestSK"]),

--- a/TestDataAggregator/Services/AzureAnalyticsResponseUtility.cs
+++ b/TestDataAggregator/Services/AzureAnalyticsResponseUtility.cs
@@ -80,10 +80,13 @@ namespace TestInformationAggregator.Services
 		/// </summary>
 		/// <param name="workItemMatch"> The work item found that is having it's bugs searched for</param>
 		/// <param name="workItems">The list of all work items</param>
+		/// <param name="workItemType"> The workitem type to filter by</param>
+		/// <param name="linkTypes"> The link types to filter the link by. If not provided the comparison is ignored</param>
 		/// <returns> The bug ids attached to the matched work item</returns>
-		public IEnumerable<JToken> GetBugLinksFromMatch(JToken workItemMatch, JArray workItems)
+		public IEnumerable<JToken> GetLinksFromMatch(JToken workItemMatch, JArray workItems, string workItemType, List<string> linkTypes = null)
 		{
-			var bugLinks = new List<JToken>();
+			var links = new List<JToken>();
+			linkTypes ??= new List<string>();
 
 			foreach (var link in workItemMatch["Links"])
 			{
@@ -92,13 +95,15 @@ namespace TestInformationAggregator.Services
 				var targetWorkItem = workItems
 					.FirstOrDefault(x => (string)x["WorkItemId"] == (string)link["TargetWorkItemId"]);
 
-				if (targetWorkItem != null && (string)(targetWorkItem["WorkItemType"]) == "Bug")
+				if (targetWorkItem != null && 
+					(string)targetWorkItem["WorkItemType"] == workItemType &&
+					!linkTypes.Any() ? true : linkTypes.Any(x => x == (string)link["LinkTypeName"]))
 				{
-					bugLinks.Add(targetWorkItem);
+					links.Add(targetWorkItem);
 				}
 			}
 
-			return bugLinks;
+			return links;
 		}
 	}
 }

--- a/TestDataAggregator/Services/JsonConfigManager.cs
+++ b/TestDataAggregator/Services/JsonConfigManager.cs
@@ -25,11 +25,6 @@ namespace TestInformationAggregator.Services
 		{
 			this.Configuration = JsonConvert.DeserializeObject<TestInfoAggregatorConfig>(
 				File.ReadAllText(Path.Combine(this.GetAssemblyPath(), configFileName)));
-
-			if (string.IsNullOrEmpty(this.Configuration.OutputDirectory))
-			{
-				this.Configuration.OutputDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
* Updated header to include the new user story ids header.
* Added logic to get the UserStories linked to the test case and add them to the TestInformation for reporting
* Modified logic to apply to all WorkItemTypes and LinkTypes by passing them as params for method GetLinkedItemMatches()
* Refactored method to create bugs as linked ids to work for any int enumerable
* setting up the delimiter of the file to be set in construction